### PR TITLE
(#33) removed max width config from mobile menu, not needed

### DIFF
--- a/src/_includes/partials/header.liquid
+++ b/src/_includes/partials/header.liquid
@@ -13,7 +13,7 @@
     <button @click="menuOpen = !menuOpen" class="flex md:hidden"><i class="fa fa-bars"></i></button>
   </div>
   <div id="mobileMenu" x-show="menuOpen"
-       class="fixed inset-y-0 right-0 z-10 w-full max-w-sm overflow-y-auto ring-1 ring-gray-100 bg-white">
+       class="fixed inset-y-0 right-0 z-10 w-full overflow-y-auto ring-1 ring-gray-100 bg-white">
     <div class="flex items-center justify-between p-6 border-b">
       <a class="flex items-center gap-x-4 text-black hover:no-underline" href="/">
         <img class="w-12 h-12 rounded-full" src="/img/logo.png"/>


### PR DESCRIPTION
This change allows the mobile menu to use all available width to display the menu rather than restricting its max width based on breakpoint.

fixes #33