### PR TITLE
(#54) separate home layout and updated footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samer.kanjo.net",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "The personal web site of Samer Kanjo",
   "keywords": [],
   "homepage": "https://github.com/skanjo/samer.kanjo.net/blob/master/README.md",

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -2,19 +2,25 @@
 <html lang="en">
 {% include "partials/head.njk" %}
 <body>
+
+{% block header %}
 {% include "partials/header.njk" %}
+{% endblock %}
+
+{% block content %}
 <main class="p-6 lg:px-8 max-w-4xl mx-auto">
   {{ content | safe }}
 </main>
-<footer class="p-6 lg:px-8 max-w-4xl mx-auto">
-  <div class="flex flex-col sm:justify-between sm:items-center sm:flex-row py-4">
-    <a href="{{ site.githubRepoUrl }}/edit/main/{{ page.inputPath }}" target="_blank">
-      Edit this page on GitHub <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>
-    <span class="text-sm">Last Updated: {% tsFormat page.date %}</span>
-  </div>
-  <div class="flex flex-col items-center text-xs text-gray-500 pt-4">
-    {% copyrightNotice %}
-  </div>
+{% endblock %}
+
+{% block footer %}
+<footer
+  class="px-6 lg:px-8 py-10 max-w-4xl mx-auto flex flex-col sm:justify-between sm:items-center sm:flex-row border-t">
+  <a href="{{ site.githubRepoUrl }}/edit/main/{{ page.inputPath }}" target="_blank">
+    Edit this page on GitHub <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>
+  <span class="text-sm">Last Updated: {% tsFormat page.date %}</span>
 </footer>
+{% endblock %}
+
 </body>
 </html>

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -1,0 +1,8 @@
+{% extends 'src/_includes/layouts/base.njk' %}
+
+{% block footer %}
+<footer
+  class="px-6 lg:px-8 py-10 max-w-4xl mx-auto border-t flex flex-row sm:justify-between sm:items-center sm:flex-col">
+  {% copyrightNotice %}
+</footer>
+{% endblock %}

--- a/src/index.md
+++ b/src/index.md
@@ -1,13 +1,15 @@
 ---
-layout: layouts/base.njk
-date: 'git Last Modified'
+layout: layouts/home.njk
 ---
 
 ## Blog
+
 Just what you would expect.
 
 ## Projects
+
 List of personal projects.
 
 ## Reference
+
 Explanation and example usage of operations.


### PR DESCRIPTION
The home page footer now only contains the copyright while all other pages only contain the edit link and last modified date.

Now using Nunjucks template inheritance to vary the content of pages.

resolves #54