### PR TITLE
(#60) add next and previous links to bytes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samer.kanjo.net",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "description": "The personal web site of Samer Kanjo",
   "keywords": [],
   "homepage": "https://github.com/skanjo/samer.kanjo.net/blob/master/README.md",

--- a/src/_includes/layouts/byte.njk
+++ b/src/_includes/layouts/byte.njk
@@ -1,9 +1,17 @@
 {% extends 'src/_includes/layouts/full_width.njk' %}
 
+{% from "src/_includes/macros/page_links.njk" import renderPageLinks %}
+
 {% block main %}
-<div class="flex flex-col">
-  <h1>{{ title }}</h1>
-  <span>{{ publicationDate | parseDate | formatDateFull }}</span>
-</div>
-{{ content | safe }}
+<article>
+  <div class="flex flex-col">
+    <h1>{{ title }}</h1>
+    <span>{{ publicationDate | parseDate | formatDateFull }}</span>
+  </div>
+  {{ content | safe }}
+</article>
+{% endblock %}
+
+{% block pagination %}
+{{ renderPageLinks(collections.bytes, page, "Newer", "Older") }}
 {% endblock %}

--- a/src/_includes/layouts/full_width.njk
+++ b/src/_includes/layouts/full_width.njk
@@ -12,6 +12,9 @@
     {% endblock %}
   </main>
 
+  {% block pagination %}
+  {% endblock %}
+
   {% block footer %}
   {% include 'partials/content_footer.njk' %}
   {% endblock %}

--- a/src/_includes/macros/page_links.njk
+++ b/src/_includes/macros/page_links.njk
@@ -1,0 +1,30 @@
+{#
+Create previous and next link navigation in order to traverse the collection from the current page. The names of the
+links are configurable based on use case.
+
+Note: When using the default 11ty filters in this Nunjucks macro, the `page` object is not defined and the reason it is
+passed as an argument to this macros. In addition, the code path of the filter will fail if the language code is not
+provided. Since I only support English language I am defaulting the value here. See the 11ty source for the filter on
+GitHub to review:
+- https://github.com/11ty/eleventy/blob/v2.0.1/src/defaultConfig.js#L37
+- https://github.com/11ty/eleventy/blob/v2.0.1/src/Filters/GetLocaleCollectionItem.js#L23
+#}
+
+{% macro renderPageLinks(collection, page, prevName = 'Previous', nextName = 'Next') %}
+
+{% set prevItem = collection | getPreviousCollectionItem(page, "en") %}
+{% set nextItem = collection | getNextCollectionItem(page, "en") %}
+
+{% if prevItem or nextItem %}
+  <nav class="p-6 flex justify-between items-center border-t">
+    {% if prevItem %}
+      <a href="{{ prevItem.url }}"><< {{ prevName }}</a>
+    {% endif %}
+    <span></span>
+    {% if nextItem %}
+      <a href="{{ nextItem.url }}">{{ nextName }} >></a>
+    {% endif %}
+  </nav>
+{% endif %}
+
+{% endmacro %}


### PR DESCRIPTION
Had an issue using the default 11ty `getPreviousCollectionItem` and `getNextCollectionItem` filters. When using these filters in a macro the `page` object is not available. It is possible to pass the `page` object however a bug in the code checks value of `this.page.lang` to find the current language to resolve a locale page and results in an error despite passing in the `page`. The workaround is to also pass `langCode` which bypasses the bug. 11ty code references are below.

- https://github.com/11ty/eleventy/blob/v2.0.1/src/defaultConfig.js#L37
- https://github.com/11ty/eleventy/blob/v2.0.1/src/Filters/GetLocaleCollectionItem.js#L23

Current solution passes `page` object from the template and then pass `page` and hardcoded `langCode` to the filter in the macro.

resolves #60 