### PR TITLE
(#67) open external links in a new window

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,5 +1,7 @@
 const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
 const {DateTime} = require("luxon");
+const markdownIt = require("markdown-it");
+const markdownItLinkAttributes = require('markdown-it-link-attributes');
 
 /** @param {import("@11ty/eleventy").UserConfig} eleventyConfig */
 module.exports = function (eleventyConfig) {
@@ -21,6 +23,19 @@ module.exports = function (eleventyConfig) {
   } else {
     eleventyConfig.addPassthroughCopy({"node_modules/alpinejs/dist/cdn.js": "js/alpine.js"});
   }
+
+  // --- Libraries
+
+  eleventyConfig.setLibrary('md', markdownIt({
+      html: true
+    }).use(markdownItLinkAttributes, {
+      pattern: /^https?:\/\//,
+      attrs: {
+        target: '_blank',
+        rel: 'noopener noreferrer'
+      }
+    })
+  );
 
   // --- Plugins
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samer.kanjo.net",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "description": "The personal web site of Samer Kanjo",
   "keywords": [],
   "homepage": "https://github.com/skanjo/samer.kanjo.net/blob/master/README.md",
@@ -25,6 +25,7 @@
     "@tailwindcss/typography": "0.5.12",
     "autoprefixer": "10.4.19",
     "luxon": "3.4.4",
+    "markdown-it-link-attributes": "4.0.1",
     "npm-run-all": "4.1.5",
     "postcss": "8.4.38",
     "rimraf": "5.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       luxon:
         specifier: 3.4.4
         version: 3.4.4
+      markdown-it-link-attributes:
+        specifier: ^4.0.1
+        version: 4.0.1
       npm-run-all:
         specifier: 4.1.5
         version: 4.1.5
@@ -866,6 +869,9 @@ packages:
   luxon@3.4.4:
     resolution: {integrity: sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==}
     engines: {node: '>=12'}
+
+  markdown-it-link-attributes@4.0.1:
+    resolution: {integrity: sha512-pg5OK0jPLg62H4k7M9mRJLT61gUp9nvG0XveKYHMOOluASo9OEF13WlXrpAp2aj35LbedAy3QOCgQCw0tkLKAQ==}
 
   markdown-it@13.0.2:
     resolution: {integrity: sha512-FtwnEuuK+2yVU7goGn/MJ0WBZMM9ZPgU9spqlFs7/A/pDIUNSOQZhUgOqYCficIuR2QaFnrt8LHqBWsbTAoI5w==}
@@ -2413,6 +2419,8 @@ snapshots:
       yallist: 4.0.0
 
   luxon@3.4.4: {}
+
+  markdown-it-link-attributes@4.0.1: {}
 
   markdown-it@13.0.2:
     dependencies:


### PR DESCRIPTION
I discovered the need for this while writing my first blog post. With this support in place I can update other pages to use markdown rather than HTML for links.

I applied this change to the branch I was using for the blog post. Normally I would have created a branch for the issue but since I discovered I needed this change while authoring the post I applied it to the post branch and created this PR for what I would consider an infrastructure change. I will follow this up with the post itself as a separate PR.

Merging this change will have no effect on the content of the site. This is more preparation for using markdown links in markdown files, which is forthcoming. Other markdown pages using HTML for links will be updated once this change is merged.

resolves #67 